### PR TITLE
Add more detailed installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,33 @@ mismatch of any existing observed UMIs for a start position, it will be merged a
 considered a duplicate. The mismatch can occur at any position, regardless of the
 IUPAC sequence you're using.
 
-##Requires
+## Installation
+
+umitools has two requirements: [pysam][] and [editdist][].
+Use pip to install [pysam].
 
 ```
-pip install pysam editdist
+pip install pysam
 ```
+
+[editdist] has to be downloaded and installed from source ([Downloads page][editdist-download]).
+
+```
+wget https://py-editdist.googlecode.com/files/py-editdist-0.3.tar.gz
+tar xzf py-editdist-0.3.tar.gz
+cd py-editdist-0.3/
+python setup.py install
+```
+
+Finally download and install umitools from source.
+
+```
+wget -O umitools-master.zip https://github.com/brwnj/umitools/archive/master.zip
+unzip umitools-master.zip
+cd umitools-master
+python setup.py install
+```
+
+[pysam]: https://pypi.python.org/pypi/pysam
+[editdist]: https://pypi.python.org/pypi/editdist/0.1
+[editdist-download]: https://code.google.com/p/py-editdist/downloads/list


### PR DESCRIPTION
I was unable to install editdist with pip, so I've added instructions on how to download it and install it from source.

```
$ pip install editdist
Collecting editdist
  Could not find a version that satisfies the requirement editdist (from versions: )
  Some externally hosted files were ignored as access to them may be unreliable (use --allow-external editdist to allow).
No matching distribution found for editdist
```

Also, since not everyone that will want to use umitools will be familiar with the Python packaging system, I added explicit instructions on how to download and install umitools from source.