### PR TITLE
Fix choices parameter for `--end` to be integer.

### DIFF
--- a/umitools/umitools.py
+++ b/umitools/umitools.py
@@ -341,7 +341,7 @@ def main():
                        help='reads with untrimmed UMI')
     fastq.add_argument('umi', metavar='UMI',
                        help='IUPAC UMI sequence, e.g. NNNNNV')
-    fastq.add_argument('--end', choices=['5', '3'], default=5, type=int,
+    fastq.add_argument('--end', choices=[5, 3], default=5, type=int,
                        help="UMI location on the read")
     fastq.add_argument('--verbose', action='store_true',
                        help="print UMI stats to stderr")


### PR DESCRIPTION
When running `trim.sh`, the `--end` argument does not accept integers.

```
$ umitools trim --end 5 unprocessed_fastq NNNNNV
usage: umitools trim [-h] [--end {5,3}] [--verbose] [--top TOP] FASTQ UMI
umitools trim: error: argument --end: invalid choice: 5 (choose from '5', '3')
```

I updated the `choices` for `--end` to be the integers `[5, 3]` instead of the strings. According to the argparse docs on [choices](https://docs.python.org/dev/library/argparse.html#choices):

> Note that inclusion in the choices container is checked after any type conversions have been performed, so the type of the objects in the choices container should match the type specified